### PR TITLE
Added docs for transform and profile component

### DIFF
--- a/docs/pipeline/profile.md
+++ b/docs/pipeline/profile.md
@@ -1,0 +1,34 @@
+# Profile Component
+
+## How it works
+- Candidate Keys: A candidate key is a collection of attributes, the values of which uniquely identify a row (i.e., there are not two rows with identical values for those attributes). In Data Preparer, candidate key information informs what type of join operation is used to combine tables.
+
+
+- Inclusion Dependencies: Inclusion dependencies describe overlaps between the values in the attributes of columns in sources. In Data Preparer, inclusion dependencies are used to identify where there is an opportunity to join two tables.
+
+## Example
+In the figure below, it is indicated that the values inGoodread.details are contained within those of RainforestBooks.title, with an overlap of 0.667. This indicates that 66.7% of the values in Goodread.details can be found in RainforestBooks.title. Note that this notion of overlap is not symmetrical, and we can also see that the reverse overlap (i.e. the fraction of values in RainforestBooks.title that are also contained in Goodread.details is only 0.278).
+
+![inclusion-deps](https://i.imgur.com/DrslRCx.png)
+
+## Configurations in the control panel
+![profiling-config](https://i.imgur.com/5ra1ubM.png)
+Profiling parameters configure the discovery of candidate keys and the discovery of inclusion dependencies. 
+
+#### Candidate key discovery parameters:
+- **Detect candidate keys**: whether to search for candidate key attributes or not. This is enabled by default.
+- **Max candidate key size**: the maximum number of attributes that can be used in a candidate key. We recommend this is kept quite low (e.g. 1), as the number of candidate keys in tables with many attributes can grow rapidly
+
+#### Inclusion dependency discovery parameters:
+- **Overlap threshold**: only inclusion dependencies with at least this fraction of overlap will be used in joins. Note that inclusion dependencies are kept when the overlap in either direction exceeds the overlap threshold.
+- **Matches only**: Restrict inclusion dependency discovery only to source tables that have at least one attribute matching an end product attribute.
+- **Candidate keys only**: Restrict inclusion dependency discovery only to attributes that are candidate keys.
+
+> Note: These latter two parameters can be used to reduce the number of inclusion dependencies retained, to those that are most relevant to the wrangling task at hand.
+
+## Steering profiling: 
+It is possible to exclude an inclusion dependency or a candidate key in the explain window for the profiling component. As with the matches component, the exclude column can be used to toggle the availability of the inclusion dependency or candidate key in the wrangling process. 
+
+![steering-profiling](https://i.imgur.com/WNEf8tw.png)
+
+In Data Preparer, inclusion dependencies are used in mapping generation to identify when joins can be carried out, so excluding an inclusion dependency means that the attributes in the dependency will not be joined. Similarly, candidate keys are used in mapping generation to determine which attributes are used to join tables, and which join operator to use. As a result, excluding a candidate key will reduce the likelihood that the attributes involved in the key will participate in join conditions.

--- a/docs/pipeline/transform.md
+++ b/docs/pipeline/transform.md
@@ -1,0 +1,80 @@
+# Transform Component
+
+## What it does
+A format transformation is a change to the way that attribute values are presented. 
+#### For example, 
+- names in different sources could be of the form Forename Surname or Firstname Surname
+- URLs can be written with or without the protocol (http, https). 
+
+## How it works
+In Data Preparer, the data context is assumed to provide the preferred representation for a type of data, and attributes that are used to populate a target attribute for which there are values in the data context may have their formats transformed to reflect that in the data context. 
+
+> Note: As the format transformation is inferred from examples, in practice format transformation only takes place when there are plenty examples in the data set and in the data context, and when the attributes in question have some form of regular structure (as in the date and URL examples above).
+
+## Example
+In the explain page in the figure below, format transformations are described in terms of examples used for training, rather than the more difficult to interpret inferred rules. We can see that in the book promotions example, values in Riverside.isbn that have an ISBN prefix have been reformatted to have this removed, reflecting the representation in MasterData.isbn, and indeed that this transformation has been applied 20 times.
+
+![transformation](https://i.imgur.com/x01T3L5.png)
+
+## Configurations in the control panel
+Format transformation infers rules that reformat from source values into the format of corresponding target values. 
+![transformation-config](https://i.imgur.com/ihf4w2U.png)
+
+#### Format transformation parameters:
+- **minimum percent**: This parameter indicates the minimum percentage of the source values that should participate in the training data for the rule inference.
+- **minimum size**: This parameter is related to minimum percent, but is specified as a number of values instead of a percentage.
+- **fail limit**: This parameter controls how many attempts the synthesis algorithm should have before concluding that a transformation cannot be found for an
+attribute. The fail limit should be less than the minimum size.
+- **source limit**: This parameter is the number of values from the source that will be considered for use in examples (or 0 for unbounded). This should be more than the minimum size.
+
+> Note: In general, attributes that contain more different formats will require higher values for all these parameters, but higher values lead to longer runtimes. We recommend that none of minimum percent, minimum size or source limit should be below 10, and that fail limit should be 5 or more.
+
+## Steering transformations
+### Add examples
+It is also possible to define custom transformation examples that will instruct the process how to transform source attribute values. This is done by selecting add examples from the submenu. 
+
+![add-examples](https://i.imgur.com/fsmCaDo.png)
+
+![add-examples-submenu](https://i.imgur.com/i4DzHD2.png)
+
+These user-defined examples will be used in conjunction to the ones obtained from the data context. Rather than revealing the internal representation of a rule, here the user can accept or reject a rule based on its effect. Selecting the eye icon in the verify column 
+
+![eye-icon](https://i.imgur.com/YASZjaU.png) 
+
+gives rise to the display in the figure below, where the specific changes that have been made to the values in the isbn column can be seen. The user can then approve or reject the transformation using the buttons above the table
+
+![detailed-changes](https://i.imgur.com/l51zfjC.png)
+
+### Reformat
+From the submenu it is also possible to reformat source attributes to make them more consistent with those in the target. 
+
+![reformat-button](https://i.imgur.com/2MhNprC.png)
+
+![reformat](https://i.imgur.com/RkQZvYF.png)
+
+This is done by explicitly associating multiple (1 or more) source attributes with multiple target attributes. As a result, a derived table can be populated, with the reformatted source contents, informed by training data from the data context. 
+
+As an example, consider a source table that contains an address attribute, while the target schema contains attributes number, street, and town. In order to make this source more consistent with the target, address can be aligned to number, street, town.
+
+> Note: The many-to-many reformatting in this case is informed using data from the data context, though in this case the training data should all come from the same table in the data context. The data context must contain data that can be aligned with every distinct pattern of values in the source. 
+
+![reformat-example](https://i.imgur.com/M7HltV9.png)
+
+So for example, if here are address values of the form 15 Cardiff Road, Swansea and 26 Mauldeth Road South, Manchester, then there will need to be examples that cover street names containing two and three words in the data context, and at least one of these examples should contain similar literal values to those in the source. This is most likely to be achieved without creating custom training data when the data context contains reference or master data. When attribute reformatting is successful, a new table is created, in the same source as the original source table.
+
+### Add expression
+From the submenu, the user can also add custom transformation expressions to modify the contents of source attributes directly by selecting add expression.
+
+![add-expression-button](https://i.imgur.com/l3sDTKl.png)
+
+![add-expression-example](https://i.imgur.com/aLEmGYR.png)
+
+Expressions can either modify an existing attribute, or add a new one with the results of the expression as its contents. For instance, the expression: UPPER(”source_table”.”attribute”) will convert the values of the defined attribute to upper case. 
+
+Expressions can contain any number of functions and attributes. In practice, running an expression will result in an execution of a SQL query of the form: UPDATE source_table SET attribute=expression. Transformations are not part of the wrangling process.
+
+## When it runs
+Transformation expressions, as well as attribute reformats, 
+#### are both executed: 
+1. at the request of the user, and 
+2. upon scenario initialisation, if the property transform.apply_transformations has been set to yes.

--- a/docs/quick-start/starter-project.md
+++ b/docs/quick-start/starter-project.md
@@ -69,7 +69,8 @@ You can view the output from each transducer by clicking on any of them.
 Congratulations! You have finished going through the basics with datapreparer.
 
 #### Let's review what we just went through
-- What just happened? With very little evidence, Data Preparer has had a go at wrangling a collection of sources into a target – here, only a few sources, but there could have been many more.
-- Why is this good? This is good because a significant manual effort is required to carry out even preliminary wrangling over a collection of sources in other data preparation systems.
+- **What just happened?** With very little evidence, Data Preparer has had a go at wrangling a collection of sources into a target – here only a few sources, but there could have been many more.
+- **Why is this good?** This is good because in other data preparation systems significant manual effort is required to carry out even preliminary wrangling over a collection of sources. In other data preparation systems, manual effort tends to be required for each data set and each wrangling step, so data context helps to provide cost-effective data preparation.
+- **What more is needed?** So far, no indication has been provided as to what result features are most important. With automated data preparation, alternative results can be produced rapidly, so an opportunity exists to tailor the wrangling process to the task in hand. (Look at the [setting priorities section](../guides/setting-priorities/intro.md))
 
 In Data Preparer, an initial result can be obtained much more quickly. Of course, this initial result can be improved upon, but data preparation has been essentially hands-off.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,8 +50,8 @@ nav:
       - Transducers:
           - Match: 'index.md'
           - Repair: 'index.md'
-          - Transform: 'index.md'
-          - Profile: 'index.md'
+          - Transform: 'pipeline/transform.md'
+          - Profile: 'pipeline/profile.md'
           - Map: 'index.md'
           - Select: 'index.md'
   - Open Source Self Help: 


### PR DESCRIPTION
For the transformation section, I added some steering components because it really helps explain a lot about what the transform component can and should do. 

What do you all think, I feel like I should leave it out to the refining solutions section, but that would remove a lot of context for the transformation component. Is there a way to separate them but still include the extra context for the transformation component?